### PR TITLE
Fix Mesa compatibility

### DIFF
--- a/discom_agent.py
+++ b/discom_agent.py
@@ -3,8 +3,8 @@ from mesa import Agent
 import random
 
 class DISCOMAgent(Agent):
-    def __init__(self, unique_id, model):
-        super().__init__(unique_id, model)
+    def __init__(self, model):
+        super().__init__(model)
         self.forecasted_peak_demand = random.uniform(500, 1000)
         self.procured_capacity = 0
         self.total_cost = 0

--- a/generator_agent.py
+++ b/generator_agent.py
@@ -3,8 +3,8 @@ from mesa import Agent
 import random
 
 class GeneratorAgent(Agent):
-    def __init__(self, unique_id, model):
-        super().__init__(unique_id, model)
+    def __init__(self, model):
+        super().__init__(model)
         self.capacity = random.uniform(50, 500)
         self.technology = random.choice(["coal", "solar", "wind", "battery"])
         self.fixed_cost = random.uniform(1000, 2000)
@@ -21,13 +21,16 @@ class GeneratorAgent(Agent):
 
         # Retirement decision
         if self.years_unprofitable >= 3:
-            print(f"Generator {self.unique_id} retiring due to sustained unprofitability.")
-            self.model.schedule.remove(self)
+            print(
+                f"Generator {self.unique_id} retiring due to sustained unprofitability."
+            )
+            self.remove()
             return
 
         # Investment decision based on return
         expected_profit = self.last_year_revenue - self.last_year_cost
         if expected_profit > 0 and random.random() < 0.2:
-            new_capacity = GeneratorAgent(self.model.next_id(), self.model)
-            self.model.schedule.add(new_capacity)
-            print(f"New Generator {new_capacity.unique_id} added due to expected profitability.")
+            new_capacity = GeneratorAgent(self.model)
+            print(
+                f"New Generator {new_capacity.unique_id} added due to expected profitability."
+            )

--- a/regulator_agent.py
+++ b/regulator_agent.py
@@ -3,13 +3,13 @@ from mesa import Agent
 import random
 
 class RegulatorAgent(Agent):
-    def __init__(self, unique_id, model, market_type):
-        super().__init__(unique_id, model)
+    def __init__(self, model, market_type):
+        super().__init__(model)
         self.reserve_margin = 0.1
         self.market_type = market_type
 
     def centralized_auction(self, discom, needed_capacity):
-        generators = [a for a in self.model.schedule.agents if hasattr(a, 'bid_price')]
+        generators = [a for a in self.model.agents if hasattr(a, 'bid_price')]
         generators.sort(key=lambda g: g.bid_price())
 
         total = 0
@@ -33,7 +33,7 @@ class RegulatorAgent(Agent):
         return total, cost
 
     def bilateral_contracts(self, discom, needed_capacity):
-        generators = [a for a in self.model.schedule.agents if hasattr(a, 'bid_price')]
+        generators = [a for a in self.model.agents if hasattr(a, 'bid_price')]
         random.shuffle(generators)
         total = 0
         cost = 0


### PR DESCRIPTION
## Summary
- update agent constructors for Mesa 3.x
- drop BaseScheduler usage and rely on built‑in `AgentSet`
- adjust generator retirement and creation
- simplify model initialization and step logic

## Testing
- `python run.py`

------
https://chatgpt.com/codex/tasks/task_e_6841ecab07dc8323af3c773cd52f2063